### PR TITLE
Disable TELEMETRY_MAVLINK for bootloader

### DIFF
--- a/radio/src/targets/common/arm/stm32/bootloader/CMakeLists.txt
+++ b/radio/src/targets/common/arm/stm32/bootloader/CMakeLists.txt
@@ -146,6 +146,7 @@ remove_definitions(-DCLI)
 remove_definitions(-DSEMIHOSTING)
 remove_definitions(-DUSB_SERIAL)
 remove_definitions(-DWATCHDOG)
+remove_definitions(-DTELEMETRY_MAVLINK)
 
 add_definitions(-DBOOT)
 


### PR DESCRIPTION
Disable TELEMETRY_MAVLINK for bootloader for it to compile when CLI & DEBUG are set.